### PR TITLE
Sell interface orders display order + Categories now passed as properties to Prepare interface

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -22,7 +22,8 @@ class Item extends React.Component {
     lowerPrice    : React.PropTypes.number,
     effectivePrice: React.PropTypes.number,
     items         : React.PropTypes.array,
-    onAddItemClick: React.PropTypes.func
+    onAddItemClick: React.PropTypes.func,
+    category      : React.PropTypes.string
   };
 
   render() {
@@ -39,7 +40,8 @@ class Item extends React.Component {
       name      : this.props.name,
       price     : this.props.price,
       lowerPrice: this.props.lowerPrice,
-      items     : this.props.items
+      items     : this.props.items,
+      category  : this.props.category.charAt(0).toUpperCase() + this.props.category.slice(1)
     };
 
     if (this.props.items) {

--- a/src/components/PendingOrders.jsx
+++ b/src/components/PendingOrders.jsx
@@ -52,36 +52,56 @@ class PendingOrders extends React.Component {
   }
 
   render() {
+    const ordersPending = this.props.orders.filter(order => order.status === "pending");
+    ordersPending.sort((a, b) => {
+      if (a.created - b.created === 0) {
+        return a.name.localeCompare(b.name);
+      }
+
+      return b.created - a.created;
+    });
+
+    const ordersInPrep = this.props.orders.filter(order => order.status === "prepare");
+    ordersInPrep.sort((a, b) => {
+      if (a.created - b.created === 0) {
+        return a.name.localeCompare(b.name);
+      }
+
+      return a.created - b.created;
+    });
+
+    const ordersReady = this.props.orders.filter(order => order.status === "ready");
+    ordersReady.sort((a, b) => {
+      if (a.created - b.created === 0) {
+        return a.name.localeCompare(b.name);
+      }
+
+      return a.created - b.created;
+    });
+
+    const orders = [...ordersReady, ...ordersInPrep, ...ordersPending];
+
     return (
       <div className="b-sell__page__orders">
-        {this.props.orders
-            .sort((a, b) => {
-              if (a.created - b.created === 0) {
-                return a.name.localeCompare(b.name);
-              }
+          {orders.map(order => {
+              const orderClasses = classNames(
+                'b-sell__page__orders__order',
+                `b-sell__page__orders__order--${order.status}`
+              );
 
-              return a.created - b.created;
+              const orderName = order.items ? order.items.filter(i => i).map(i => i.name).join(', ') : order.name;
+
+              return (
+                <div
+                  className={orderClasses}
+                  onTouchStart={() => this.startTimer(order)}
+                  onMousedown={() => this.startTimer(order)}
+                  onTouchEnd={() => this.stopTimer()}
+                  onMouseUp={() => this.stopTimer()}>
+                  #{order.code} {orderName}
+                </div>
+              );
             })
-            .map(order => {
-
-            const orderClasses = classNames(
-              'b-sell__page__orders__order',
-              `b-sell__page__orders__order--${order.status}`
-            );
-
-            const orderName = order.items ? order.items.filter(i => i).map(i => i.name).join(', ') : order.name;
-
-            return (
-              <div
-                className={orderClasses}
-                onTouchStart={() => this.startTimer(order)}
-                onMousedown={() => this.startTimer(order)}
-                onTouchEnd={() => this.stopTimer()}
-                onMouseUp={() => this.stopTimer()}>
-                #{order.code} {orderName}
-              </div>
-            );
-          })
         }
       </div>
     );

--- a/src/components/Prepare.jsx
+++ b/src/components/Prepare.jsx
@@ -51,10 +51,18 @@ class Prepare extends React.Component {
     const ordersCounter = [];
     orders.map(order => {
       if (order.status != "ready") {
-        if (!ordersCounter[order.name]) {
-          ordersCounter[order.name] = {prepare:0, pending:0}
+        if (order.category == "General") {
+          if (!ordersCounter[order.name]) {
+            ordersCounter[order.name] = {prepare:0, pending:0}
+          }
+          ordersCounter[order.name][order.status]++;
         }
-        ordersCounter[order.name][order.status]++;
+        else {
+          if (!ordersCounter[order.category]) {
+            ordersCounter[order.category] = {prepare:0, pending:0}
+          }
+          ordersCounter[order.category][order.status]++;
+        }
       }
     })
 


### PR DESCRIPTION
* On Sell interface, orders are now displayed in the "right" order :
First of all we get "ready" orders (ordered by the oldest to the newest).
Between this and "pending" orders, we have "prepare" orders (ordered by the oldest to the newest too).
To finish, we can find "pending" orders (ordered from the newest to the oldest).

* On Prepare interface, the summary now uses category instead of name except for the "general" category where it uses the name to display the summary. The summary is now able to summarize every pizzas under the "Pizzas" category instead of displaying every kind of pizzas independently.