### PR TITLE
Fixed orders disappearing problem & New functions in Prepare

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -41,7 +41,7 @@ class Item extends React.Component {
       price     : this.props.price,
       lowerPrice: this.props.lowerPrice,
       items     : this.props.items,
-      category  : this.props.category.charAt(0).toUpperCase() + this.props.category.slice(1)
+      category  : this.props.category
     };
 
     if (this.props.items) {

--- a/src/components/Prepare.jsx
+++ b/src/components/Prepare.jsx
@@ -47,7 +47,7 @@ class Prepare extends React.Component {
         return a.created - b.created;
       })
 
-    // for each item, count per status
+    // for each item, count per status and organize per category
     const ordersCounter = [];
     orders.map(order => {
       if (order.status != "ready") {

--- a/src/components/Prepare.jsx
+++ b/src/components/Prepare.jsx
@@ -29,17 +29,26 @@ class Prepare extends React.Component {
         status
       });
 
-    if (status === 'ready') {
+    /*if (status === 'ready') {
       setTimeout(() => {
         this.refs[order.id].style.height  = '0px';
         this.refs[order.id].style.padding = '0 20px';
       }, 500);
-    }
+    }*/
   }
 
   render() {
-    const orders = this.props.orders
-      .sort((a, b) => {
+    const ordersReady = this.props.orders.filter(order => order.status === "ready");
+    ordersReady.sort((a, b) => {
+      if (a.created - b.created === 0) {
+        return a.name.localeCompare(b.name);
+      }
+
+      return a.created - b.created;
+    });
+
+    const ordersNotReady = this.props.orders.filter(order => ((order.status === "pending") || (order.status === "prepare")));
+      ordersNotReady.sort((a, b) => {
         if (a.created - b.created === 0) {
           return a.name.localeCompare(b.name);
         }
@@ -47,21 +56,24 @@ class Prepare extends React.Component {
         return a.created - b.created;
       })
 
+    const orders = [...ordersNotReady, ...ordersReady];
+
     // for each item, count per status and organize per category
     const ordersCounter = [];
     orders.map(order => {
       if (order.status != "ready") {
-        if (order.category == "General") {
+        if (order.category == "general") {
           if (!ordersCounter[order.name]) {
             ordersCounter[order.name] = {prepare:0, pending:0}
           }
           ordersCounter[order.name][order.status]++;
         }
         else {
-          if (!ordersCounter[order.category]) {
-            ordersCounter[order.category] = {prepare:0, pending:0}
+          const category = order.category.charAt(0).toUpperCase() + order.category.slice(1); // In order to use the category with an uppercase char as the first later
+          if (!ordersCounter[category]) {
+            ordersCounter[category] = {prepare:0, pending:0}
           }
-          ordersCounter[order.category][order.status]++;
+          ordersCounter[category][order.status]++;
         }
       }
     })

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -5,7 +5,8 @@
   min-height: 200px;
   justify-content: center;
   left: 50%;
-  min-width: 400px;
+  /*min-width: 400px;*/
+  min-width: 1200px;
   padding: 20px;
   position: fixed;
   top: 100px;

--- a/src/styles/prepare.css
+++ b/src/styles/prepare.css
@@ -83,7 +83,6 @@
   display: flex;
   margin: 10px auto;
   overflow: hidden;
-  transition: height .2s ease-out, padding .2s ease-out;
   width: 1200px;
   padding: 20px;
 }

--- a/src/styles/prepare.css
+++ b/src/styles/prepare.css
@@ -186,3 +186,28 @@
   margin-top: 50px;
   font-weight: 300;
 }
+
+.b-prepare__orders__wrap {
+  display:flex;
+  flex:1;
+  flex-direction: column;
+}
+
+.b-prepare__orders__tabs {
+  display: flex;
+}
+
+.b-prepare__orders__tabs__tab {
+  background-color: #35415b;
+  color: #ffe500;
+  cursor: pointer;
+  flex: 1;
+  font-size: 24px;
+  padding: 5px 10px;
+  text-align: center;
+}
+
+.b-prepare__orders__tabs__tab--active {
+  background-color: #ffe500;
+  color: #35415b;
+}


### PR DESCRIPTION
* Orders disappearing fixed
* Tabs for "not ready" & "ready" in Prepare display, used to display respectively "not ready" & "ready" orders
* Orders resume now uses categories instead of item name except for "Général"